### PR TITLE
[FEATURE] #8 SeachScreen 구현

### DIFF
--- a/app/src/main/java/com/haman/jetsnackclone/ui/home/Home.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/home/Home.kt
@@ -41,6 +41,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.haman.jetsnackclone.R
 import com.haman.jetsnackclone.ui.component.JetsnackSurface
+import com.haman.jetsnackclone.ui.home.search.Search
 import com.haman.jetsnackclone.ui.theme.JetsnackCloneTheme
 import com.haman.jetsnackclone.ui.theme.JetsnackTheme
 
@@ -50,6 +51,9 @@ fun NavGraphBuilder.addHomeGraph(
 ) {
     composable(HomeSections.FEED.route) { from ->
         Feed(onSnackClick = { id -> onSnackSelected(id, from) }, modifier = modifier)
+    }
+    composable(HomeSections.SEARCH.route) { from ->
+        Search(onSnackClick = { id -> onSnackSelected(id, from) }, modifier = modifier)
     }
     composable(HomeSections.PROFILE.route) { Profile() }
 }

--- a/app/src/main/java/com/haman/jetsnackclone/ui/home/search/Categories.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/home/search/Categories.kt
@@ -1,0 +1,163 @@
+package com.haman.jetsnackclone.ui.home.search
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.dp
+import com.haman.jetsnackclone.model.SearchCategory
+import com.haman.jetsnackclone.model.SearchCategoryCollection
+import com.haman.jetsnackclone.model.SearchRepo
+import com.haman.jetsnackclone.ui.component.SnackImage
+import com.haman.jetsnackclone.ui.component.VerticalGrid
+import com.haman.jetsnackclone.ui.theme.JetsnackCloneTheme
+import com.haman.jetsnackclone.ui.theme.JetsnackTheme
+import java.lang.Integer.max
+
+@Composable
+fun SearchCategories(
+    categories: List<SearchCategoryCollection>
+) {
+    LazyColumn {
+        itemsIndexed(items = categories) { index, collection ->
+            SearchCategoryCollection(
+                collection = collection,
+                index = index
+            )
+        }
+    }
+    Spacer(modifier = Modifier.height(8.dp))
+}
+
+@Composable
+fun SearchCategoryCollection(
+    collection: SearchCategoryCollection,
+    index: Int,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier) {
+        Text(
+            text = collection.name,
+            style = MaterialTheme.typography.h6,
+            color = JetsnackTheme.colors.textPrimary,
+            modifier = Modifier
+                .heightIn(min = 56.dp)
+                .padding(horizontal = 24.dp, vertical = 4.dp)
+                .wrapContentHeight()
+        )
+        VerticalGrid(Modifier.padding(horizontal = 16.dp)) {
+            val gradient = when (index % 2) {
+                0 -> JetsnackTheme.colors.gradient2_2 // 짝수
+                else -> JetsnackTheme.colors.gradient2_3 // 홏수
+            }
+            collection.categories.forEach { category ->
+                SearchCategory(
+                    category = category,
+                    gradient = gradient,
+                    modifier = Modifier.padding(8.dp)
+                )
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+    }
+}
+
+private val MinImageSize = 134.dp
+private val CategoryShape = RoundedCornerShape(10.dp)
+private const val CategoryTextProportion = 0.6f
+
+@Composable
+fun SearchCategory(
+    category: SearchCategory,
+    gradient: List<Color>,
+    modifier: Modifier = Modifier
+) {
+    Layout(
+        modifier = modifier
+            .aspectRatio(1.45f)
+            .shadow(elevation = 3.dp, shape = CategoryShape)
+            .clip(CategoryShape)
+            .background(Brush.horizontalGradient(gradient))
+            .clickable { },
+        content = {
+            Text(
+                text = category.name,
+                style = MaterialTheme.typography.subtitle1,
+                color = JetsnackTheme.colors.textSecondary,
+                modifier = Modifier
+                    .padding(4.dp)
+                    .padding(start = 8.dp)
+            )
+            SnackImage(
+                imageUrl = category.imageUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+    ) { measurables, constraints ->
+        val textWidth = (constraints.maxWidth * CategoryTextProportion).toInt()
+        val textPlaceable = measurables[0].measure(Constraints.fixedWidth(textWidth))
+
+        val imageSize = max(MinImageSize.roundToPx(), constraints.maxHeight)
+        val imagePlaceable = measurables[1].measure(Constraints.fixed(imageSize, imageSize))
+
+        layout(
+            constraints.maxWidth, constraints.minHeight
+        ) {
+            textPlaceable.placeRelative(0, (constraints.maxHeight - textPlaceable.height) / 2)
+            imagePlaceable.placeRelative(
+                textWidth,
+                (constraints.maxHeight - imagePlaceable.height) / 2
+            )
+        }
+    }
+}
+
+@Preview("search category", showBackground = true)
+@Preview("search category dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun SearchCategoryCollectionPreview() {
+    JetsnackCloneTheme {
+        SearchCategoryCollection(
+            collection = SearchRepo.getCategories().first(),
+            index = 0
+        )
+    }
+}
+
+@Preview("search category", showBackground = true)
+@Preview("search category dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun SearchCategoryCollectionEvenIndexPreview() {
+    JetsnackCloneTheme {
+        SearchCategoryCollection(
+            collection = SearchRepo.getCategories().first(),
+            index = 1
+        )
+    }
+}
+
+@Preview("search category", showBackground = true)
+@Preview("search category dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun SearchCategoriesPreview() {
+    JetsnackCloneTheme {
+        SearchCategories(
+            categories = SearchRepo.getCategories()
+        )
+    }
+}

--- a/app/src/main/java/com/haman/jetsnackclone/ui/home/search/Result.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/home/search/Result.kt
@@ -1,0 +1,237 @@
+package com.haman.jetsnackclone.ui.home.search
+
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ChainStyle
+import androidx.constraintlayout.compose.ConstraintLayout
+import com.haman.jetsnackclone.R
+import com.haman.jetsnackclone.model.Filter
+import com.haman.jetsnackclone.model.Snack
+import com.haman.jetsnackclone.model.filters
+import com.haman.jetsnackclone.model.snacks
+import com.haman.jetsnackclone.ui.component.*
+import com.haman.jetsnackclone.ui.theme.JetsnackCloneTheme
+import com.haman.jetsnackclone.ui.theme.JetsnackTheme
+
+@Composable
+fun SearchResults(
+    searchResults: List<Snack>,
+    filters: List<Filter>,
+    onSnackClick: (Long) -> Unit
+) {
+    Column {
+        FilterBar(filters = filters, onShowFilters = {})
+        Text(
+            text = stringResource(R.string.search_count, searchResults.size),
+            style = MaterialTheme.typography.h6,
+            color = JetsnackTheme.colors.textPrimary,
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 4.dp)
+        )
+        LazyColumn {
+            itemsIndexed(items = searchResults) { index, snack ->
+                SearchResult(
+                    snack = snack,
+                    onSnackClick = onSnackClick,
+                    showDivider = index != 0
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SearchResult(
+    snack: Snack,
+    onSnackClick: (Long) -> Unit,
+    showDivider: Boolean,
+    modifier: Modifier = Modifier
+) {
+    ConstraintLayout(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onSnackClick(snack.id) }
+            .padding(horizontal = 24.dp)
+    ) {
+        val (divider, image, name, tag, priceSpacer, price, add) = createRefs()
+        createVerticalChain(name, tag, priceSpacer, price, chainStyle = ChainStyle.Packed)
+        if (showDivider) {
+            JetsnackDivider(
+                modifier = Modifier.constrainAs(divider) {
+                    linkTo(start = parent.start, end = parent.end)
+                    top.linkTo(parent.top)
+                }
+            )
+        }
+        SnackImage(
+            imageUrl = snack.imageUrl,
+            contentDescription = null,
+            modifier = Modifier
+                .size(100.dp)
+                .constrainAs(image) {
+                    linkTo(
+                        top = parent.top,
+                        topMargin = 16.dp,
+                        bottom = parent.bottom,
+                        bottomMargin = 16.dp
+                    )
+                    start.linkTo(parent.start)
+                }
+        )
+        Text(
+            text = snack.name,
+            style = MaterialTheme.typography.subtitle1,
+            color = JetsnackTheme.colors.textSecondary,
+            modifier = Modifier.constrainAs(name) {
+                linkTo(
+                    start = image.end,
+                    startMargin = 16.dp,
+                    end = add.start,
+                    endMargin = 16.dp,
+                    bias = 0f
+                )
+            }
+        )
+        Text(
+            text = snack.tagline,
+            style = MaterialTheme.typography.body1,
+            color = JetsnackTheme.colors.textHelp,
+            modifier = Modifier.constrainAs(tag) {
+                linkTo(
+                    start = image.end,
+                    startMargin = 16.dp,
+                    end = add.start,
+                    endMargin = 16.dp,
+                    bias = 0f
+                )
+            }
+        )
+        Spacer(
+            Modifier
+                .height(8.dp)
+                .constrainAs(priceSpacer) {
+                    linkTo(top = tag.bottom, bottom = price.top)
+                }
+        )
+        Text(
+            text = snack.price.toString(),
+            style = MaterialTheme.typography.subtitle1,
+            color = JetsnackTheme.colors.textPrimary,
+            modifier = Modifier.constrainAs(price) {
+                linkTo(
+                    start = image.end,
+                    startMargin = 16.dp,
+                    end = add.start,
+                    endMargin = 16.dp,
+                    bias = 0f
+                )
+            }
+        )
+        JetsnackButton(
+            onClick = { /* todo */ },
+            shape = CircleShape,
+            contentPadding = PaddingValues(0.dp),
+            modifier = Modifier
+                .size(36.dp)
+                .constrainAs(add) {
+                    linkTo(top = parent.top, bottom = parent.bottom)
+                    end.linkTo(parent.end)
+                }
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Add,
+                contentDescription = stringResource(R.string.label_add)
+            )
+        }
+    }
+}
+
+@Composable
+fun NoResult(
+    query: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxSize()
+            .wrapContentSize()
+            .padding(24.dp)
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.empty_state_search),
+            contentDescription = null
+        )
+        Spacer(Modifier.height(24.dp))
+        Text(
+            text = stringResource(R.string.search_no_matches, query),
+            style = MaterialTheme.typography.subtitle1,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.search_no_matches_retry),
+            style = MaterialTheme.typography.body2,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview(name = "noResult", showBackground = true)
+@Composable
+fun NoResultPreview() {
+    JetsnackCloneTheme {
+        NoResult(query = "demo")
+    }
+}
+
+@Preview("default")
+@Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview("large font", fontScale = 2f)
+@Composable
+private fun SearchResultPreview() {
+    JetsnackCloneTheme {
+        JetsnackSurface {
+            SearchResult(
+                snack = snacks[0],
+                onSnackClick = { },
+                showDivider = true
+            )
+        }
+    }
+}
+
+@Preview("default")
+@Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview("large font", fontScale = 2f)
+@Composable
+private fun SearchResultsPreview() {
+    JetsnackCloneTheme {
+        JetsnackSurface {
+            SearchResults(
+                searchResults = snacks,
+                filters = filters,
+                onSnackClick = { }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/haman/jetsnackclone/ui/home/search/Result.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/home/search/Result.kt
@@ -164,7 +164,7 @@ fun SearchResult(
 }
 
 @Composable
-fun NoResult(
+fun NoResults(
     query: String,
     modifier: Modifier = Modifier
 ) {
@@ -200,7 +200,7 @@ fun NoResult(
 @Composable
 fun NoResultPreview() {
     JetsnackCloneTheme {
-        NoResult(query = "demo")
+        NoResults(query = "demo")
     }
 }
 

--- a/app/src/main/java/com/haman/jetsnackclone/ui/home/search/Search.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/home/search/Search.kt
@@ -1,0 +1,224 @@
+package com.haman.jetsnackclone.ui.home.search
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.haman.jetsnackclone.R
+import com.haman.jetsnackclone.model.*
+import com.haman.jetsnackclone.ui.component.JetsnackDivider
+import com.haman.jetsnackclone.ui.component.JetsnackSurface
+import com.haman.jetsnackclone.ui.theme.JetsnackCloneTheme
+import com.haman.jetsnackclone.ui.theme.JetsnackTheme
+
+@Composable
+fun Search(
+    onSnackClick: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+    state: SearchState = rememberSearchState()
+) {
+    JetsnackSurface(modifier = modifier.fillMaxSize()) {
+        Column {
+            Spacer(modifier = Modifier.statusBarsPadding())
+            // 검색 입력란
+            SearchBar(
+                query = state.query,
+                onQueryChange = { state.query = it },
+                searchFocused = state.focused,
+                onSearchFocusChange = { state.focused = it },
+                onClearQuery = { state.query = TextFieldValue("") },
+                searching = state.searching
+            )
+            JetsnackDivider()
+
+            /**
+             * query 가 바뀔 때마다 서버에 요청
+             */
+            LaunchedEffect(state.query.text) {
+                state.searching = true
+                state.searchResults = SearchRepo.search(state.query.text)
+                state.searching = false
+            }
+            when (state.searchDisplay) {
+                SearchDisplay.Categories -> SearchCategories(state.categories)
+                SearchDisplay.Suggestions -> SearchSuggestions(
+                    suggestions = state.suggestions,
+                    onSuggestionSelect = { suggestion -> state.query = TextFieldValue(suggestion) }
+                )
+                SearchDisplay.Results -> SearchResults(
+                    state.searchResults,
+                    state.filters,
+                    onSnackClick
+                )
+                SearchDisplay.NoResults -> NoResults(state.query.text)
+            }
+        }
+    }
+}
+@Composable
+private fun rememberSearchState(
+    query: TextFieldValue = TextFieldValue(""),
+    focused: Boolean = false,
+    searching: Boolean = false,
+    categories: List<SearchCategoryCollection> = SearchRepo.getCategories(),
+    suggestions: List<SearchSuggestionGroup> = SearchRepo.getSuggestions(),
+    filters: List<Filter> = SnackRepo.getFilters(),
+    searchResults: List<Snack> = emptyList()
+): SearchState {
+    return remember {
+        SearchState(
+            query = query,
+            focused = focused,
+            searching = searching,
+            categories = categories,
+            suggestions = suggestions,
+            filters = filters,
+            searchResults = searchResults
+        )
+    }
+}
+
+enum class SearchDisplay {
+    Categories, Suggestions, Results, NoResults
+}
+
+@Stable
+class SearchState(
+    query: TextFieldValue, // 검색 키워드
+    focused: Boolean,
+    searching: Boolean, // 검색 중
+    categories: List<SearchCategoryCollection>, // 카테고리
+    suggestions: List<SearchSuggestionGroup>, // 제안
+    filters: List<Filter>, // 검색 결과 filtering
+    searchResults: List<Snack> // 검색 결과
+) {
+    var query by mutableStateOf(query)
+    var focused by mutableStateOf(focused)
+    var searching by mutableStateOf(searching)
+    var categories by mutableStateOf(categories)
+    var suggestions by mutableStateOf(suggestions)
+    var filters by mutableStateOf(filters)
+    var searchResults by mutableStateOf(searchResults)
+    val searchDisplay: SearchDisplay
+        get() = when {
+            !focused && query.text.isEmpty() -> SearchDisplay.Categories // 초기
+            focused && query.text.isEmpty() -> SearchDisplay.Suggestions // 입력 중
+            searchResults.isEmpty() -> SearchDisplay.NoResults // 검색 결과 없음
+            else -> SearchDisplay.Results // 결과
+        }
+}
+
+private val IconSize = 48.dp
+
+@Composable
+private fun SearchBar(
+    query: TextFieldValue,
+    onQueryChange: (TextFieldValue) -> Unit,
+    searchFocused: Boolean,
+    onSearchFocusChange: (Boolean) -> Unit,
+    onClearQuery: () -> Unit,
+    searching: Boolean,
+    modifier: Modifier = Modifier
+) {
+    JetsnackSurface(
+        color = JetsnackTheme.colors.uiFloated,
+        contentColor = JetsnackTheme.colors.textSecondary,
+        shape = MaterialTheme.shapes.small,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .padding(horizontal = 24.dp, vertical = 8.dp)
+    ) {
+        Box(Modifier.fillMaxSize()) {
+            if (query.text.isEmpty()) {
+                SearchHint()
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .wrapContentHeight()
+            ) {
+                if (searchFocused) {
+                    IconButton(onClick = onClearQuery) {
+                        Icon(
+                            imageVector = Icons.Outlined.ArrowBack,
+                            tint = JetsnackTheme.colors.iconPrimary,
+                            contentDescription = stringResource(R.string.label_back)
+                        )
+                    }
+                }
+                BasicTextField(
+                    value = query,
+                    onValueChange = onQueryChange,
+                    modifier = Modifier
+                        .weight(1f)
+                        .onFocusChanged {
+                            onSearchFocusChange(it.isFocused)
+                        }
+                )
+                if (searching) {
+                    CircularProgressIndicator(
+                        color = JetsnackTheme.colors.iconPrimary,
+                        modifier = Modifier
+                            .padding(horizontal = 6.dp)
+                            .size(36.dp)
+                    )
+                } else {
+                    Spacer(Modifier.width(IconSize)) // balance arrow icon
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchHint() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxSize()
+            .wrapContentSize()
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Search,
+            tint = JetsnackTheme.colors.textHelp,
+            contentDescription = stringResource(R.string.label_search)
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            text = stringResource(R.string.search_jetsnack),
+            color = JetsnackTheme.colors.textHelp
+        )
+    }
+}
+
+@Preview("default")
+@Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview("large font", fontScale = 2f)
+@Composable
+private fun SearchBarPreview() {
+    JetsnackCloneTheme {
+        JetsnackSurface {
+            SearchBar(
+                query = TextFieldValue(""),
+                onQueryChange = { },
+                searchFocused = false,
+                onSearchFocusChange = { },
+                onClearQuery = { },
+                searching = false
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/haman/jetsnackclone/ui/home/search/Suggestions.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/home/search/Suggestions.kt
@@ -1,0 +1,91 @@
+package com.haman.jetsnackclone.ui.home.search
+
+import android.content.res.Configuration
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.haman.jetsnackclone.model.SearchRepo
+import com.haman.jetsnackclone.model.SearchSuggestionGroup
+import com.haman.jetsnackclone.ui.component.JetsnackSurface
+import com.haman.jetsnackclone.ui.theme.JetsnackCloneTheme
+import com.haman.jetsnackclone.ui.theme.JetsnackTheme
+
+@Composable
+fun SearchSuggestions(
+    suggestions: List<SearchSuggestionGroup>,
+    onSuggestionSelect: (String) -> Unit
+) {
+    LazyColumn {
+        suggestions.forEach { suggestionGroup ->
+            item {
+                SuggestionHeader(suggestionGroup.name)
+            }
+            items(items = suggestionGroup.suggestions) { suggestion ->
+                Suggestion(
+                    suggestion = suggestion,
+                    onSuggestionSelect = onSuggestionSelect,
+                    modifier = Modifier.fillParentMaxWidth()
+                )
+            }
+            item {
+                Spacer(Modifier.height(4.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SuggestionHeader(
+    name: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = name,
+        style = MaterialTheme.typography.h6,
+        color = JetsnackTheme.colors.textPrimary,
+        modifier = modifier
+            .heightIn(min = 56.dp)
+            .padding(horizontal = 24.dp, vertical = 4.dp)
+            .wrapContentHeight()
+    )
+}
+
+@Composable
+private fun Suggestion(
+    suggestion: String,
+    onSuggestionSelect: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = suggestion,
+        style = MaterialTheme.typography.subtitle1,
+        modifier = modifier
+            .heightIn(min = 48.dp)
+            .clickable { onSuggestionSelect(suggestion) }
+            .padding(start = 24.dp)
+            .wrapContentSize(Alignment.CenterStart)
+    )
+}
+
+@Preview("default")
+@Preview("dark theme", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview("large font", fontScale = 2f)
+@Composable
+fun PreviewSuggestions() {
+    JetsnackCloneTheme {
+        JetsnackSurface {
+            SearchSuggestions(
+                suggestions = SearchRepo.getSuggestions(),
+                onSuggestionSelect = { }
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,8 +31,11 @@
     <string name="grab_beverage">Grab a beverage and check back later!</string>
 
     <!-- Search -->
+    <string name="search_jetsnack">Search Jetsnack</string>
     <string name="search_no_matches">No matches for “%1s”</string>
     <string name="search_no_matches_retry">Try broadening your search</string>
     <string name="label_add">Add to cart</string>
     <string name="search_count">%1d items</string>
+    <string name="label_search">Perform search</string>
+    <string name="label_back">Back</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,4 +29,10 @@
     <!-- Profile -->
     <string name="work_in_progress">This is currently work in progress</string>
     <string name="grab_beverage">Grab a beverage and check back later!</string>
+
+    <!-- Search -->
+    <string name="search_no_matches">No matches for “%1s”</string>
+    <string name="search_no_matches_retry">Try broadening your search</string>
+    <string name="label_add">Add to cart</string>
+    <string name="search_count">%1d items</string>
 </resources>


### PR DESCRIPTION
### 📌 내용
HomeScreen 하위에 SearchScreen 구현 및 사용 기술 정리

### 🛠 Done
- [x] Results.kt 구현
- [x] Categories.kt 구현
- [x] Suggestions.kt 구현
- [x] Search.kt 구현
<img width="250" alt="스크린샷 2023-03-23 오후 8 36 05" src="https://user-images.githubusercontent.com/22411296/227191874-3a08191d-908e-4322-b6a4-5d8ec34d9e0b.png">

### 🏠 관련 Issue
Closed #8 

### 🪴 학습
1. Search App State
2. query에 따라 다른 리스트를 보여주는 기법
3. onFocusChanged