### PR TITLE
[FEATURE] #9 CartScreen 구현

### DIFF
--- a/app/src/main/java/com/haman/jetsnackclone/ui/component/Snack.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/component/Snack.kt
@@ -49,7 +49,7 @@ fun SnackCollection(
     snackCollection: SnackCollection,
     onSnackClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
-    index: Int,
+    index: Int = 0,
     highlight: Boolean = true
 ) {
     Column(modifier = modifier) {

--- a/app/src/main/java/com/haman/jetsnackclone/ui/home/Home.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/home/Home.kt
@@ -41,6 +41,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.haman.jetsnackclone.R
 import com.haman.jetsnackclone.ui.component.JetsnackSurface
+import com.haman.jetsnackclone.ui.home.cart.Cart
 import com.haman.jetsnackclone.ui.home.search.Search
 import com.haman.jetsnackclone.ui.theme.JetsnackCloneTheme
 import com.haman.jetsnackclone.ui.theme.JetsnackTheme
@@ -54,6 +55,9 @@ fun NavGraphBuilder.addHomeGraph(
     }
     composable(HomeSections.SEARCH.route) { from ->
         Search(onSnackClick = { id -> onSnackSelected(id, from) }, modifier = modifier)
+    }
+    composable(HomeSections.CART.route) { from ->
+        Cart(onSnackClick = { id -> onSnackSelected(id, from) }, modifier = modifier)
     }
     composable(HomeSections.PROFILE.route) { Profile() }
 }

--- a/app/src/main/java/com/haman/jetsnackclone/ui/home/cart/Cart.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/home/cart/Cart.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -150,7 +151,7 @@ private fun CartContent(
                         ) {
                             if (offsetX > -(140.dp)) {
                                 val iconAlpha: Float by animateFloatAsState(
-                                    if (offsetX < - (120.dp)) 0f else 1f,
+                                    if (offsetX < -(120.dp)) 0f else 1f,
                                     animationSpec = swipeAnimationSpec()
                                 )
 
@@ -194,6 +195,14 @@ private fun CartContent(
             }
         }
         item {
+            SummaryItem(
+                subtotal = orderLines.fold(0) { acc, orderLine ->
+                    acc + (orderLine.snack.price * orderLine.count)
+                },
+                shippingCosts = 369
+            )
+        }
+        item {
             SnackCollection(
                 snackCollection = inspiredByCart,
                 onSnackClick = onSnackClick,
@@ -201,6 +210,76 @@ private fun CartContent(
             )
             Spacer(Modifier.height(56.dp))
         }
+    }
+}
+
+@Composable
+fun SummaryItem(
+    subtotal: Long,
+    shippingCosts: Long,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier) {
+        Text(
+            text = stringResource(R.string.cart_summary_header),
+            style = MaterialTheme.typography.h6,
+            color = JetsnackTheme.colors.brand,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .padding(horizontal = 24.dp)
+                .heightIn(min = 56.dp)
+                .wrapContentHeight()
+        )
+        Row(modifier = Modifier.padding(horizontal = 24.dp)) {
+            Text(
+                text = stringResource(R.string.cart_subtotal_label),
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier
+                    .weight(1f)
+                    .wrapContentWidth(Alignment.Start)
+                    .alignBy(LastBaseline)
+            )
+            Text(
+                text = subtotal.toString(),
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier.alignBy(LastBaseline)
+            )
+        }
+        Row(modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)) {
+            Text(
+                text = stringResource(R.string.cart_shipping_label),
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier
+                    .weight(1f)
+                    .wrapContentWidth(Alignment.Start)
+                    .alignBy(LastBaseline)
+            )
+            Text(
+                text = shippingCosts.toString(),
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier.alignBy(LastBaseline)
+            )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        JetsnackDivider()
+        Row(modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)) {
+            Text(
+                text = stringResource(R.string.cart_total_label),
+                style = MaterialTheme.typography.body1,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = 16.dp)
+                    .wrapContentWidth(Alignment.End)
+                    .alignBy(LastBaseline)
+            )
+            Text(
+                text = (subtotal + shippingCosts).toString(),
+                style = MaterialTheme.typography.subtitle1,
+                modifier = Modifier.alignBy(LastBaseline)
+            )
+        }
+        JetsnackDivider()
     }
 }
 

--- a/app/src/main/java/com/haman/jetsnackclone/ui/home/cart/Cart.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/home/cart/Cart.kt
@@ -1,0 +1,272 @@
+package com.haman.jetsnackclone.ui.home.cart
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ChainStyle
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.haman.jetsnackclone.R
+import com.haman.jetsnackclone.model.OrderLine
+import com.haman.jetsnackclone.model.SnackCollection
+import com.haman.jetsnackclone.model.SnackRepo
+import com.haman.jetsnackclone.model.SnackbarManager
+import com.haman.jetsnackclone.ui.component.*
+import com.haman.jetsnackclone.ui.home.DestinationBar
+import com.haman.jetsnackclone.ui.theme.JetsnackCloneTheme
+import com.haman.jetsnackclone.ui.theme.JetsnackTheme
+
+@Composable
+fun Cart(
+    onSnackClick: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: CartViewModel = CartViewModel(SnackbarManager, SnackRepo)
+) {
+    val orderLines = viewModel.orderLines.collectAsState()
+    val inspiredByCart = remember { SnackRepo.getInspiredByCart() }
+    Cart(
+        orderLines = orderLines.value,
+        removeSnack = viewModel::removeSnack,
+        increaseItem = viewModel::increaseSnackCount,
+        decreaseItem = viewModel::decreaseSnackCount,
+        inspiredByCart = inspiredByCart,
+        onSnackClick = onSnackClick,
+        modifier = modifier
+    )
+}
+
+@Composable
+fun Cart(
+    orderLines: List<OrderLine>,
+    removeSnack: (Long) -> Unit,
+    increaseItem: (Long) -> Unit,
+    decreaseItem: (Long) -> Unit,
+    inspiredByCart: SnackCollection,
+    onSnackClick: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    JetsnackSurface(modifier = modifier.fillMaxSize()) {
+        Box {
+            CartContent(
+                orderLines = orderLines,
+                removeSnack = removeSnack,
+                increaseItemCount = increaseItem,
+                decreaseItemCount = decreaseItem,
+                inspiredByCart = inspiredByCart,
+                onSnackClick = onSnackClick
+            )
+            DestinationBar(modifier = Modifier.align(Alignment.TopCenter))
+        }
+    }
+}
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+private fun CartContent(
+    orderLines: List<OrderLine>, // 주문 내역
+    removeSnack: (Long) -> Unit, // 제거
+    increaseItemCount: (Long) -> Unit,
+    decreaseItemCount: (Long) -> Unit,
+    inspiredByCart: SnackCollection,
+    onSnackClick: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val resources = LocalContext.current.resources
+    val snackCountFormattedString = remember(orderLines.size, resources) {
+        resources.getQuantityString(
+            R.plurals.cart_order_count,
+            orderLines.size, orderLines.size
+        )
+    }
+    LazyColumn(modifier) {
+        item {
+            Spacer(
+                Modifier.windowInsetsTopHeight(
+                    WindowInsets.statusBars.add(WindowInsets(top = 56.dp))
+                )
+            )
+            Text(
+                text = stringResource(R.string.cart_order_header, snackCountFormattedString),
+                style = MaterialTheme.typography.h6,
+                color = JetsnackTheme.colors.brand,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .heightIn(min = 56.dp)
+                    .padding(horizontal = 24.dp, vertical = 4.dp)
+                    .wrapContentHeight()
+            )
+        }
+        items(orderLines) { orderLine ->
+            SwipeDismissItem(
+                background = { offsetX ->
+                    /*Background color changes from light gray to red when the
+                    swipe to delete with exceeds 160.dp*/
+                    val backgroundColor = if (offsetX < -(160.dp)) {
+                        JetsnackTheme.colors.error
+                    } else {
+                        JetsnackTheme.colors.uiFloated
+                    }
+                },
+            ) {
+                CartItem(
+                    orderLine = orderLine,
+                    removeSnack = removeSnack,
+                    increaseItem = increaseItemCount,
+                    decreaseItem = decreaseItemCount,
+                    onSnackClick = onSnackClick
+                )
+            }
+        }
+        item {
+            SnackCollection(
+                snackCollection = inspiredByCart,
+                onSnackClick = onSnackClick,
+                highlight = false
+            )
+            Spacer(Modifier.height(56.dp))
+        }
+    }
+}
+
+@Composable
+fun CartItem(
+    orderLine: OrderLine,
+    removeSnack: (Long) -> Unit,
+    increaseItem: (Long) -> Unit,
+    decreaseItem: (Long) -> Unit,
+    onSnackClick: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val snack = orderLine.snack
+    ConstraintLayout(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onSnackClick(snack.id) }
+            .background(JetsnackTheme.colors.uiBackground)
+            .padding(horizontal = 24.dp)
+    ) {
+        val (divider, image, name, tag, priceSpacer, price, remove, quantity) = createRefs()
+        createVerticalChain(name, tag, priceSpacer, price, chainStyle = ChainStyle.Packed)
+        SnackImage(
+            imageUrl = snack.imageUrl,
+            contentDescription = null,
+            modifier = Modifier
+                .size(100.dp)
+                .constrainAs(image) {
+                    top.linkTo(parent.top, margin = 16.dp)
+                    bottom.linkTo(parent.bottom, margin = 16.dp)
+                    start.linkTo(parent.start)
+                }
+        )
+        Text(
+            text = snack.name,
+            style = MaterialTheme.typography.subtitle1,
+            color = JetsnackTheme.colors.textSecondary,
+            modifier = Modifier.constrainAs(name) {
+                linkTo(
+                    start = image.end,
+                    startMargin = 16.dp,
+                    end = remove.start,
+                    endMargin = 16.dp,
+                    bias = 0f
+                )
+            }
+        )
+        IconButton(
+            onClick = { removeSnack(snack.id) },
+            modifier = Modifier
+                .constrainAs(remove) {
+                    top.linkTo(parent.top)
+                    end.linkTo(parent.end)
+                }
+                .padding(top = 12.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                tint = JetsnackTheme.colors.iconSecondary,
+                contentDescription = stringResource(R.string.label_remove)
+            )
+        }
+        Text(
+            text = snack.tagline,
+            style = MaterialTheme.typography.body1,
+            color = JetsnackTheme.colors.textHelp,
+            modifier = Modifier.constrainAs(tag) {
+                linkTo(
+                    start = image.end,
+                    startMargin = 16.dp,
+                    end = parent.end,
+                    endMargin = 16.dp,
+                    bias = 0f
+                )
+            }
+        )
+        Spacer(
+            Modifier
+                .height(8.dp)
+                .constrainAs(priceSpacer) {
+                    linkTo(top = tag.bottom, bottom = price.top)
+                }
+        )
+        Text(
+            text = snack.price.toString(),
+            style = MaterialTheme.typography.subtitle1,
+            color = JetsnackTheme.colors.textPrimary,
+            modifier = Modifier.constrainAs(price) {
+                linkTo(
+                    start = image.end,
+                    end = quantity.start,
+                    startMargin = 16.dp,
+                    endMargin = 16.dp,
+                    bias = 0f
+                )
+            }
+        )
+        QuantitySelector(
+            count = orderLine.count,
+            decreaseItemCount = { decreaseItem(snack.id) },
+            increaseItemCount = { increaseItem(snack.id) },
+            modifier = Modifier.constrainAs(quantity) {
+                baseline.linkTo(price.baseline)
+                end.linkTo(parent.end)
+            }
+        )
+        JetsnackDivider(
+            Modifier.constrainAs(divider) {
+                linkTo(start = parent.start, end = parent.end)
+                top.linkTo(parent.bottom)
+            }
+        )
+    }
+}
+
+@Preview("default")
+@Preview("dark theme", uiMode = UI_MODE_NIGHT_YES)
+@Preview("large font", fontScale = 2f)
+@Composable
+private fun CartPreview() {
+    JetsnackCloneTheme {
+        Cart(onSnackClick = {})
+    }
+}

--- a/app/src/main/java/com/haman/jetsnackclone/ui/home/cart/CartViewModel.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/home/cart/CartViewModel.kt
@@ -1,9 +1,6 @@
 package com.haman.jetsnackclone.ui.home.cart
 
-import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewmodel.CreationExtras
 import com.haman.jetsnackclone.R
 import com.haman.jetsnackclone.model.OrderLine
 import com.haman.jetsnackclone.model.SnackRepo

--- a/app/src/main/java/com/haman/jetsnackclone/ui/home/cart/CartViewModel.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/home/cart/CartViewModel.kt
@@ -1,7 +1,9 @@
 package com.haman.jetsnackclone.ui.home.cart
 
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.haman.jetsnackclone.R
 import com.haman.jetsnackclone.model.OrderLine
 import com.haman.jetsnackclone.model.SnackRepo
@@ -56,13 +58,5 @@ class CartViewModel(
     }
 
     companion object {
-        fun provideFactory(
-            snackbarManager: SnackbarManager = SnackbarManager,
-            snackRepository: SnackRepo = SnackRepo
-        ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
-            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return CartViewModel(snackbarManager, snackRepository) as T
-            }
-        }
     }
 }

--- a/app/src/main/java/com/haman/jetsnackclone/ui/home/cart/CartViewModel.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/home/cart/CartViewModel.kt
@@ -1,0 +1,68 @@
+package com.haman.jetsnackclone.ui.home.cart
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.haman.jetsnackclone.R
+import com.haman.jetsnackclone.model.OrderLine
+import com.haman.jetsnackclone.model.SnackRepo
+import com.haman.jetsnackclone.model.SnackbarManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class CartViewModel(
+    private val snackbarManager: SnackbarManager,
+    snackRepository: SnackRepo
+) : ViewModel() {
+
+    private val _orderLines: MutableStateFlow<List<OrderLine>> =
+        MutableStateFlow(snackRepository.getCart())
+    val orderLines: StateFlow<List<OrderLine>> = _orderLines.asStateFlow()
+
+    private var requestCount = 0
+    private fun shouldRandomlyFail(): Boolean = requestCount % 5 == 0
+
+    fun increaseSnackCount(snackId: Long) {
+        if (shouldRandomlyFail().not()) {
+            val currentCount = _orderLines.value.first { it.snack.id == snackId }.count
+            updateSnackCount(snackId, currentCount + 1)
+        } else {
+            snackbarManager.showMessage(R.string.cart_increase_error)
+        }
+    }
+
+    fun decreaseSnackCount(snackId: Long) {
+        if (shouldRandomlyFail().not()) {
+            val currentCount = _orderLines.value.first { it.snack.id == snackId }.count
+            if (currentCount == 1) {
+                removeSnack(snackId)
+            } else {
+                updateSnackCount(snackId, currentCount - 1)
+            }
+        } else {
+            snackbarManager.showMessage(R.string.cart_decrease_error)
+        }
+    }
+
+    fun removeSnack(snackId: Long) {
+        _orderLines.value = _orderLines.value.filter { it.snack.id != snackId }
+    }
+
+    private fun updateSnackCount(snackId: Long, count: Int) {
+        _orderLines.value = _orderLines.value.map {
+            if (it.snack.id == snackId) it.copy(count = count)
+            else it
+        }
+    }
+
+    companion object {
+        fun provideFactory(
+            snackbarManager: SnackbarManager = SnackbarManager,
+            snackRepository: SnackRepo = SnackRepo
+        ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return CartViewModel(snackbarManager, snackRepository) as T
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/haman/jetsnackclone/ui/home/cart/SwipeDismissItem.kt
+++ b/app/src/main/java/com/haman/jetsnackclone/ui/home/cart/SwipeDismissItem.kt
@@ -1,0 +1,42 @@
+package com.haman.jetsnackclone.ui.home.cart
+
+import androidx.compose.animation.*
+import androidx.compose.material.DismissDirection
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.SwipeToDismiss
+import androidx.compose.material.rememberDismissState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun SwipeDismissItem(
+    modifier: Modifier = Modifier,
+    directions: Set<DismissDirection> = setOf(DismissDirection.EndToStart),
+    enter: EnterTransition = expandVertically(),
+    exit: ExitTransition = shrinkVertically(),
+    background: @Composable (Offset: Dp) -> Unit,
+    content: @Composable (isDismissed: Boolean) -> Unit
+) {
+    val dismissState = rememberDismissState()
+    val isDismissed = dismissState.isDismissed(DismissDirection.EndToStart)
+    val offset = with(LocalDensity.current) { dismissState.offset.value.toDp() }
+
+    AnimatedVisibility(
+        modifier = modifier,
+        visible = !isDismissed,
+        enter = enter,
+        exit = exit
+    ) {
+        SwipeToDismiss(
+            modifier = modifier,
+            state = dismissState,
+            directions = directions,
+            background = { background(offset) },
+            dismissContent = { content(isDismissed) }
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,4 +48,6 @@
         <item quantity="other">%1d items</item>
     </plurals>
     <string name="cart_order_header">Order (%1s)</string>
+    <string name="cart_checkout">Checkout</string>
+    <string name="remove_item">Remove Item</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,4 +50,8 @@
     <string name="cart_order_header">Order (%1s)</string>
     <string name="cart_checkout">Checkout</string>
     <string name="remove_item">Remove Item</string>
+    <string name="cart_summary_header">Summary</string>
+    <string name="cart_subtotal_label">Subtotal</string>
+    <string name="cart_shipping_label">Shipping &amp; Handling</string>
+    <string name="cart_total_label">Total</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,9 @@
     <string name="cart_increase_error">There was an error and the quantity couldn\'t be increased. Please try again.</string>
     <string name="cart_decrease_error">There was an error and the quantity couldn\'t be decreased. Please try again.</string>
     <string name="label_remove">Remove item</string>
+    <plurals name="cart_order_count">
+        <item quantity="one">%1d item</item>
+        <item quantity="other">%1d items</item>
+    </plurals>
+    <string name="cart_order_header">Order (%1s)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,4 +38,9 @@
     <string name="search_count">%1d items</string>
     <string name="label_search">Perform search</string>
     <string name="label_back">Back</string>
+
+    <!-- Cart -->
+    <string name="cart_increase_error">There was an error and the quantity couldn\'t be increased. Please try again.</string>
+    <string name="cart_decrease_error">There was an error and the quantity couldn\'t be decreased. Please try again.</string>
+    <string name="label_remove">Remove item</string>
 </resources>


### PR DESCRIPTION
### 📌 내용
HomeScreen 하위에 CartScreen 구현 및 사용 기술 정리

### 🛠 Done
- [x] CartViewModel.kt 구현
- [x] SwipeDismissItem.kt 구현
- [x] Cart.kt 구현
- [x] SwipeDismissItem Background 변경

👇🏻 UI

https://user-images.githubusercontent.com/22411296/227246515-f3b76027-4b7e-48c0-9097-01b4f4ae42ba.mov

### 🏠 관련 Issue
Closed #9 

### 🪴 학습
1. SwipeToDismiss & DismissState
2. Cart 메뉴 개수 변경 로직
3. ViewModel에서 데이터를 가져오는 부분과 실제 Composable을 구분
